### PR TITLE
patch update ACS endpoints to use _plugins  #1031

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
@@ -214,9 +214,9 @@ public class Saml2SettingsProvider {
     private String buildAssertionConsumerEndpoint(String dashboardsRoot) {
 
         if (dashboardsRoot.endsWith("/")) {
-            return dashboardsRoot + "_opendistro/_security/saml/acs";
+            return dashboardsRoot + "_plugins/_security/saml/acs";
         } else {
-            return dashboardsRoot + "/_opendistro/_security/saml/acs";
+            return dashboardsRoot + "/_plugins/_security/saml/acs";
         }
     }
 


### PR DESCRIPTION
Updated the ACS endpoint builder code components. [BUG] v2.1 security plugin is still using _opendistro/_security/saml/acs #1031

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
